### PR TITLE
Core Data CUD 적용

### DIFF
--- a/ThrowAway/Product+CoreDataClass.swift
+++ b/ThrowAway/Product+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  Product+CoreDataClass.swift
+//  ThrowAway
+//
+//  Created by Sujin Jin on 2022/11/05.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(Product)
+public class Product: NSManagedObject {
+
+}

--- a/ThrowAway/Product+CoreDataProperties.swift
+++ b/ThrowAway/Product+CoreDataProperties.swift
@@ -1,0 +1,28 @@
+//
+//  Product+CoreDataProperties.swift
+//  ThrowAway
+//
+//  Created by Sujin Jin on 2022/11/05.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension Product {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<Product> {
+        return NSFetchRequest<Product>(entityName: "Product")
+    }
+
+    @NSManaged public var cleaningDay: Date?
+    @NSManaged public var title: String?
+    @NSManaged public var photo: Data?
+    @NSManaged public var memo: String?
+
+}
+
+extension Product : Identifiable {
+
+}

--- a/ThrowAway/ThrowAway.xcodeproj/project.pbxproj
+++ b/ThrowAway/ThrowAway.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		980200902916338D00E193E6 /* DateHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9802008F2916338D00E193E6 /* DateHolder.swift */; };
 		98020092291633A700E193E6 /* DateScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98020091291633A700E193E6 /* DateScrollView.swift */; };
 		980200942916343600E193E6 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980200932916343600E193E6 /* StatisticsView.swift */; };
+		9805138E2916477E00A4E9BD /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */; };
+		9805138F2916477E00A4E9BD /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */; };
 		C686F5DC29101C6B0057BB0D /* AddObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686F5DB29101C6B0057BB0D /* AddObjectView.swift */; };
 		C686F5E12910215A0057BB0D /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686F5E02910215A0057BB0D /* PhotoPicker.swift */; };
 		C6EFB9D12903AAF700C53743 /* ThrowAwayApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9D02903AAF700C53743 /* ThrowAwayApp.swift */; };
@@ -32,6 +34,8 @@
 		9802008F2916338D00E193E6 /* DateHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateHolder.swift; sourceTree = "<group>"; };
 		98020091291633A700E193E6 /* DateScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateScrollView.swift; sourceTree = "<group>"; };
 		980200932916343600E193E6 /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
+		9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataClass.swift"; sourceTree = "<group>"; };
+		9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		C686F5DB29101C6B0057BB0D /* AddObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddObjectView.swift; sourceTree = "<group>"; };
 		C686F5E02910215A0057BB0D /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		C6EFB9CD2903AAF700C53743 /* ThrowAway.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThrowAway.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -96,6 +100,8 @@
 		C6EFB9C42903AAF700C53743 = {
 			isa = PBXGroup;
 			children = (
+				9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */,
+				9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */,
 				C6EFB9CF2903AAF700C53743 /* ThrowAway */,
 				C6EFB9CE2903AAF700C53743 /* Products */,
 			);
@@ -206,7 +212,9 @@
 				C6EFB9DD2903AAFA00C53743 /* ThrowAway.xcdatamodeld in Sources */,
 				C6EFB9DA2903AAFA00C53743 /* Persistence.swift in Sources */,
 				C6EFB9D32903AAF700C53743 /* ContentView.swift in Sources */,
+				9805138E2916477E00A4E9BD /* Product+CoreDataClass.swift in Sources */,
 				98020092291633A700E193E6 /* DateScrollView.swift in Sources */,
+				9805138F2916477E00A4E9BD /* Product+CoreDataProperties.swift in Sources */,
 				980200872916326D00E193E6 /* CalendarManager.swift in Sources */,
 				980200942916343600E193E6 /* StatisticsView.swift in Sources */,
 				9802008C291632E800E193E6 /* CalendarView.swift in Sources */,

--- a/ThrowAway/ThrowAway.xcodeproj/project.pbxproj
+++ b/ThrowAway/ThrowAway.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		9805138E2916477E00A4E9BD /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */; };
 		9805138F2916477E00A4E9BD /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */; };
 		9805139E2916495100A4E9BD /* ThrowAwayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805139D2916495100A4E9BD /* ThrowAwayTests.swift */; };
+		9805139F29164A0000A4E9BD /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9D92903AAFA00C53743 /* Persistence.swift */; };
+		980513A029164A1400A4E9BD /* ThrowAway.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9DB2903AAFA00C53743 /* ThrowAway.xcdatamodeld */; };
+		980513A129164A1F00A4E9BD /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */; };
+		980513A229164A1F00A4E9BD /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */; };
 		C686F5DC29101C6B0057BB0D /* AddObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686F5DB29101C6B0057BB0D /* AddObjectView.swift */; };
 		C686F5E12910215A0057BB0D /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686F5E02910215A0057BB0D /* PhotoPicker.swift */; };
 		C6EFB9D12903AAF700C53743 /* ThrowAwayApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9D02903AAF700C53743 /* ThrowAwayApp.swift */; };
@@ -269,7 +273,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				980513A229164A1F00A4E9BD /* Product+CoreDataProperties.swift in Sources */,
 				9805139E2916495100A4E9BD /* ThrowAwayTests.swift in Sources */,
+				980513A029164A1400A4E9BD /* ThrowAway.xcdatamodeld in Sources */,
+				9805139F29164A0000A4E9BD /* Persistence.swift in Sources */,
+				980513A129164A1F00A4E9BD /* Product+CoreDataClass.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ThrowAway/ThrowAway.xcodeproj/project.pbxproj
+++ b/ThrowAway/ThrowAway.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		980200942916343600E193E6 /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 980200932916343600E193E6 /* StatisticsView.swift */; };
 		9805138E2916477E00A4E9BD /* Product+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */; };
 		9805138F2916477E00A4E9BD /* Product+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */; };
+		9805139E2916495100A4E9BD /* ThrowAwayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9805139D2916495100A4E9BD /* ThrowAwayTests.swift */; };
 		C686F5DC29101C6B0057BB0D /* AddObjectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686F5DB29101C6B0057BB0D /* AddObjectView.swift */; };
 		C686F5E12910215A0057BB0D /* PhotoPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = C686F5E02910215A0057BB0D /* PhotoPicker.swift */; };
 		C6EFB9D12903AAF700C53743 /* ThrowAwayApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9D02903AAF700C53743 /* ThrowAwayApp.swift */; };
@@ -25,6 +26,16 @@
 		C6EFB9DA2903AAFA00C53743 /* Persistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9D92903AAFA00C53743 /* Persistence.swift */; };
 		C6EFB9DD2903AAFA00C53743 /* ThrowAway.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = C6EFB9DB2903AAFA00C53743 /* ThrowAway.xcdatamodeld */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		980513982916493400A4E9BD /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C6EFB9C52903AAF700C53743 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = C6EFB9CC2903AAF700C53743;
+			remoteInfo = ThrowAway;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		980200862916326D00E193E6 /* CalendarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarManager.swift; sourceTree = "<group>"; };
@@ -36,6 +47,8 @@
 		980200932916343600E193E6 /* StatisticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatisticsView.swift; sourceTree = "<group>"; };
 		9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataClass.swift"; sourceTree = "<group>"; };
 		9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		980513942916493300A4E9BD /* ThrowAwayTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ThrowAwayTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		9805139D2916495100A4E9BD /* ThrowAwayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThrowAwayTests.swift; sourceTree = "<group>"; };
 		C686F5DB29101C6B0057BB0D /* AddObjectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddObjectView.swift; sourceTree = "<group>"; };
 		C686F5E02910215A0057BB0D /* PhotoPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPicker.swift; sourceTree = "<group>"; };
 		C6EFB9CD2903AAF700C53743 /* ThrowAway.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ThrowAway.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -48,6 +61,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		980513912916493300A4E9BD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C6EFB9CA2903AAF700C53743 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -88,6 +108,14 @@
 			path = View;
 			sourceTree = "<group>";
 		};
+		980513952916493400A4E9BD /* ThrowAwayTests */ = {
+			isa = PBXGroup;
+			children = (
+				9805139D2916495100A4E9BD /* ThrowAwayTests.swift */,
+			);
+			path = ThrowAwayTests;
+			sourceTree = "<group>";
+		};
 		C686F5DF291021450057BB0D /* AddObject */ = {
 			isa = PBXGroup;
 			children = (
@@ -103,6 +131,7 @@
 				9805138C2916477E00A4E9BD /* Product+CoreDataClass.swift */,
 				9805138D2916477E00A4E9BD /* Product+CoreDataProperties.swift */,
 				C6EFB9CF2903AAF700C53743 /* ThrowAway */,
+				980513952916493400A4E9BD /* ThrowAwayTests */,
 				C6EFB9CE2903AAF700C53743 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -111,6 +140,7 @@
 			isa = PBXGroup;
 			children = (
 				C6EFB9CD2903AAF700C53743 /* ThrowAway.app */,
+				980513942916493300A4E9BD /* ThrowAwayTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -141,6 +171,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		980513932916493300A4E9BD /* ThrowAwayTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 9805139A2916493400A4E9BD /* Build configuration list for PBXNativeTarget "ThrowAwayTests" */;
+			buildPhases = (
+				980513902916493300A4E9BD /* Sources */,
+				980513912916493300A4E9BD /* Frameworks */,
+				980513922916493300A4E9BD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				980513992916493400A4E9BD /* PBXTargetDependency */,
+			);
+			name = ThrowAwayTests;
+			productName = ThrowAwayTests;
+			productReference = 980513942916493300A4E9BD /* ThrowAwayTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		C6EFB9CC2903AAF700C53743 /* ThrowAway */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C6EFB9E02903AAFA00C53743 /* Build configuration list for PBXNativeTarget "ThrowAway" */;
@@ -165,9 +213,13 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1400;
+				LastSwiftUpdateCheck = 1330;
 				LastUpgradeCheck = 1400;
 				TargetAttributes = {
+					980513932916493300A4E9BD = {
+						CreatedOnToolsVersion = 13.3;
+						TestTargetID = C6EFB9CC2903AAF700C53743;
+					};
 					C6EFB9CC2903AAF700C53743 = {
 						CreatedOnToolsVersion = 14.0;
 					};
@@ -188,11 +240,19 @@
 			projectRoot = "";
 			targets = (
 				C6EFB9CC2903AAF700C53743 /* ThrowAway */,
+				980513932916493300A4E9BD /* ThrowAwayTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		980513922916493300A4E9BD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C6EFB9CB2903AAF700C53743 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -205,6 +265,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		980513902916493300A4E9BD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9805139E2916495100A4E9BD /* ThrowAwayTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C6EFB9C92903AAF700C53743 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -229,7 +297,53 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		980513992916493400A4E9BD /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = C6EFB9CC2903AAF700C53743 /* ThrowAway */;
+			targetProxy = 980513982916493400A4E9BD /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		9805139B2916493400A4E9BD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ddugibab.ThrowAway.ThrowAwayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ThrowAway.app/ThrowAway";
+			};
+			name = Debug;
+		};
+		9805139C2916493400A4E9BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.4;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = ddugibab.ThrowAway.ThrowAwayTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/ThrowAway.app/ThrowAway";
+			};
+			name = Release;
+		};
 		C6EFB9DE2903AAFA00C53743 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -413,6 +527,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		9805139A2916493400A4E9BD /* Build configuration list for PBXNativeTarget "ThrowAwayTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9805139B2916493400A4E9BD /* Debug */,
+				9805139C2916493400A4E9BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C6EFB9C82903AAF700C53743 /* Build configuration list for PBXProject "ThrowAway" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ThrowAway/ThrowAway/ContentView.swift
+++ b/ThrowAway/ThrowAway/ContentView.swift
@@ -12,18 +12,18 @@ struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
 
     @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
+        sortDescriptors: [NSSortDescriptor(keyPath: \Product.cleaningDay, ascending: true)],
         animation: .default)
-    private var items: FetchedResults<Item>
+    private var items: FetchedResults<Product>
 
     var body: some View {
         NavigationView {
             List {
                 ForEach(items) { item in
                     NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
+                        Text("Item at \(item.cleaningDay!, formatter: itemFormatter)")
                     } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
+                        Text(item.cleaningDay!, formatter: itemFormatter)
                     }
                 }
                 .onDelete(perform: deleteItems)
@@ -44,8 +44,8 @@ struct ContentView: View {
 
     private func addItem() {
         withAnimation {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+            let newItem = Product(context: viewContext)
+            newItem.cleaningDay = Date()
 
             do {
                 try viewContext.save()

--- a/ThrowAway/ThrowAway/Persistence.swift
+++ b/ThrowAway/ThrowAway/Persistence.swift
@@ -14,8 +14,8 @@ struct PersistenceController {
         let result = PersistenceController(inMemory: true)
         let viewContext = result.container.viewContext
         for _ in 0..<10 {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
+            let newItem = Product(context: viewContext)
+            newItem.cleaningDay = Date()
         }
         do {
             try viewContext.save()

--- a/ThrowAway/ThrowAway/ThrowAway.xcdatamodeld/ThrowAway.xcdatamodel/contents
+++ b/ThrowAway/ThrowAway/ThrowAway.xcdatamodeld/ThrowAway.xcdatamodel/contents
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="1" systemVersion="11A491" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="false" userDefinedModelVersionIdentifier="">
-    <entity name="Item" representedClassName="Item" syncable="YES" codeGenerationType="class">
-        <attribute name="timestamp" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21C52" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Product" representedClassName="Product" syncable="YES">
+        <attribute name="cleaningDay" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="memo" optional="YES" attributeType="String"/>
+        <attribute name="photo" optional="YES" attributeType="Binary"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
     </entity>
     <elements>
-        <element name="Item" positionX="-63" positionY="-18" width="128" height="44"/>
+        <element name="Product" positionX="-63" positionY="-18" width="128" height="89"/>
     </elements>
 </model>

--- a/ThrowAway/ThrowAwayTests/ThrowAwayTests.swift
+++ b/ThrowAway/ThrowAwayTests/ThrowAwayTests.swift
@@ -6,30 +6,58 @@
 //
 
 import XCTest
+import CoreData
 
 class ThrowAwayTests: XCTestCase {
+    var sut: PersistenceController!
+        override func setUpWithError() throws {
+            try super.setUpWithError()
+            self.sut = PersistenceController.shared
+        }
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
-    }
-
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-    }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
+        override func tearDownWithError() throws {
+            try super.tearDownWithError()
+            self.sut = nil
+        }
+        
+        func testCoreData_whenAddProduct() throws {
+            let viewContext = sut.container.viewContext
+            let newItem = Product(context: viewContext)
+            newItem.memo = "this is test data"
+            newItem.title = "testTitle"
+            newItem.cleaningDay = Date()
+            do {
+                try viewContext.save()
+            } catch {
+                XCTFail("Fail add Item to database")
+            }
+        }
+    
+    func testCoreData_updateProduct_byTitle() throws {
+        let viewContext = sut.container.viewContext
+        let updateTargetTitle = "testTitle"
+        let fetchRequest: NSFetchRequest<NSFetchRequestResult> = NSFetchRequest(entityName: "Product")
+        fetchRequest.predicate = NSPredicate(format: "title = %@", updateTargetTitle)
+        
+        do {
+            let fetchResults = try viewContext.fetch(fetchRequest)
+            let updatedObject = fetchResults[0] as! NSManagedObject
+            updatedObject.setValue("updated Title", forKey: "title")
+            updatedObject.setValue("updated memo", forKey: "memo")
+            try viewContext.save()
+        } catch {
+            XCTFail("Fail update Item by title")
         }
     }
-
+    
+    func testCoreData_deleteAll() throws {
+        let viewContext = sut.container.viewContext
+        let request = NSFetchRequest<NSFetchRequestResult>(entityName: "Product")
+        let deleteRequest = NSBatchDeleteRequest(fetchRequest: request)
+        do {
+            try viewContext.execute(deleteRequest)
+        } catch {
+            XCTFail("Fail delete all")
+        }
+    }
 }

--- a/ThrowAway/ThrowAwayTests/ThrowAwayTests.swift
+++ b/ThrowAway/ThrowAwayTests/ThrowAwayTests.swift
@@ -1,0 +1,35 @@
+//
+//  ThrowAwayTests.swift
+//  ThrowAwayTests
+//
+//  Created by Sujin Jin on 2022/11/05.
+//
+
+import XCTest
+
+class ThrowAwayTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
## 🙋🏻‍♀️ 리뷰어님께 🙋🏻
코어데이터를 다루는데 미숙하여 알아보는데 시간을 할애하느라 사실상 작업이 많이 안되었습니다 😭
예시 코드를 보고 수정, 삭제, 추가에 대한 테스트 코드를 돌려 봤습니다. 그리고 SQLite 에서 테스트 코드가 잘 돌아가는지 확인하는 과정을 거쳤습니다. 

## 📚 작업 사항
- [x] 엔티티 추가
- [x] 상품 추가 테스트 작성
- [x] 상품 업데이트 테스트 작성
- [x] 상품 삭제 테스트 작성

## 🌤  고민
<img width="463" alt="스크린샷 2022-11-05 오전 10 27 13" src="https://user-images.githubusercontent.com/12508578/200095510-6f9d5ef9-3ba2-4f0c-a995-70cc52bd7414.png">

- 현재 구조에서는, main 에서 PersistenceController 싱글톤 인스턴스를 생성하고 하위뷰에 `PersistenceController.container.viewContext` 를 넘겨준다
- container 는 데이터를 담고 있는 꾸러미같은 존재
- viewContext 는 NSManagedObjectContext 타입이며 managed object에 관련된 CRUD 작업을 제공한다.
- 하위뷰에서는 이 viewContext 를 사용하여 데이터에 접근할 수 있다.
- 예를들어 데이터 추가시, 하위 View 에서 사용하는 코드는 다음과 같다:

```swift
// 1.객체생성
let newItem = Product(context: viewContext)
// 2.데이터 할당
newItem.cleaningDay = Date()
// 3. 
do {
    try viewContext.save()
} catch {
    let nsError = error as NSError
    fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
}
```
<img width="468" alt="스크린샷 2022-11-05 오전 10 10 57" src="https://user-images.githubusercontent.com/12508578/200095502-d0240e2d-9552-4168-a68a-b70e5adf0e5b.png">

- DBManager 객체를 만들어 context 를 안에 숨기는 방향을 고민해 봤다.
- DBManager 는 Persistent Container 의 생성과 CRUD 를 담당한다.
- 예를들어 아래와 같은 코드이다

```swift
class CoreDataManager {
    static let shared = CoreDataManager()
    private init() {}
    let container: NSPersistentContainer
    
    func addProduct(title: String, image: Data) {
        // 상품 추가
        //container.viewContext.save()
    }
    
    func deleteProduct() {
        // 상품 삭제
        // container.viewContext.delete()
    }
}

// 클라이언트 코드
class SecondViewController: UIViewController {
	private let dataManager: CoreDataManager
	init(dataManager: CoreDataManater) {
		self.dataManater = dataManager
	}
	
	@objc func touchAddProduct() {
		dataManager.addProduct(title:image:)
	}
}
```

- 장점:
    - 클라이언트 코드가 단순해 질 수 있다.
- 단점:
    - 구조가 복잡해질 수 있다.
    - FetchRequest 와 같은 편리한 프로퍼티 래퍼를 view 단에서 직접 사용할 수 없어 불편해진다.